### PR TITLE
bug fix: error when file name contains 'cairo' string

### DIFF
--- a/api/analyse.py
+++ b/api/analyse.py
@@ -1,0 +1,30 @@
+import os
+# get number of folders under upload/temp directory
+def get_num_of_folders():
+    path = 'upload/temp'
+    num_of_folders = len(os.listdir(path))
+    return num_of_folders
+
+# get number of .cairo files under upload/temp directory recursively
+def get_num_of_files():
+    path = 'upload/temp'
+    num_of_files = 0
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith(".cairo"):
+                num_of_files += 1
+    return num_of_files
+
+# count ` /compile-scarb/` in the backend.log file
+def get_num_of_compiles():
+    path = 'backend.log'
+    num_of_compiles = 0
+    with open(path, 'r') as f:
+        for line in f:
+            if '/compile-scarb/' in line:
+                num_of_compiles += 1
+    return num_of_compiles
+
+print("users", get_num_of_folders())
+print("cairo files", get_num_of_files())
+print("compiles", get_num_of_compiles())

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate rocket;
-use rocket::figment::providers::Format;
 use rocket::serde::{json::Json, Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};

--- a/plugin/src/components/EnvironmentSelector/index.tsx
+++ b/plugin/src/components/EnvironmentSelector/index.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react'
 import { devnets } from '../../utils/network'
 import { type ConnectOptions, type DisconnectOptions } from 'get-starknet'
 import { ConnectionContext } from '../../contexts/ConnectionContext'
-import { Provider } from 'starknet'
 
 import './styles.css'
 import EnvironmentContext from '../../contexts/EnvironmentContext'

--- a/plugin/src/features/Compilation/index.tsx
+++ b/plugin/src/features/Compilation/index.tsx
@@ -437,11 +437,9 @@ const Compilation: React.FC<CompilationProps> = ({ setAccordian }) => {
           'Cairo Compilation Failed, logs can be read in the terminal log'
         )
       }
-
       setStatus('Compiling to casm...')
-
       response = await fetch(
-        `${apiUrl}/compile-to-casm/${hashDir}/${currentFilePath.replace(
+        `${apiUrl}/compile-to-casm/${hashDir}/${currentFilePath.replaceAll(
           getFileExtension(currentFilePath),
           'sierra'
         )}`,
@@ -465,7 +463,6 @@ const Compilation: React.FC<CompilationProps> = ({ setAccordian }) => {
 
       // get Json body from response
       const casm = JSON.parse(await response.text())
-
       if (casm.status !== 'Success') {
         await remixClient.terminal.log(casm.message)
 


### PR DESCRIPTION
Single file compilation was failing if the cairo file name contains `cairo` as a string. This PR fixes that