### PR TITLE
Fix: Due to starknet.js issue with detection cairo version having onl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ pnpm run deploy;
 pnpm run serve;
 ```
 
+Depending on cairo compiler +nightly may be necessary to run locally
 ```bash
 cd api;
 export VITE_URL=http://localhost:3000

--- a/plugin/src/features/Deployment/index.tsx
+++ b/plugin/src/features/Deployment/index.tsx
@@ -480,7 +480,7 @@ const Deployment: React.FC<DeploymentProps> = ({ setActiveTab }) => {
   }
 
   const handleDeploySubmit = (data: CallbackReturnType): void => {
-    handleDeploy(data.starknetjs as BigNumberish[])
+    handleDeploy(data?.starknetjs ?? (data.raw as BigNumberish[]))
   }
 
   const setContractDeclaration = (currentContract: Contract): void => {


### PR DESCRIPTION
Starknet.js fails to determine a Abi version of contracts with only constructor present as referenced [here](https://github.com/starknet-io/starknet.js/issues/1242). This is will be fixed [here](https://github.com/starknet-io/starknet.js/pull/1243). 

Due to such behavior the solution is to pass raw parameters in case starknetjs returned as undefined.