### PR TITLE
fix the horizontal scroll at the bottom

### DIFF
--- a/plugin/src/features/Plugin/styles.css
+++ b/plugin/src/features/Plugin/styles.css
@@ -15,8 +15,8 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    gap: 8px;
-    padding: 0 16px;
+    gap: 3px;
+    padding: 0 10px;
     border-bottom: 1px solid var(--light);
 }
 


### PR DESCRIPTION
## Description

This pull request fixes issue #311 by removing the horizontal scrollbar at the bottom of the plugin interface.

### Changes made:
- Modified the tab navigation styling in `plugin/src/features/Plugin/styles.css`
- Reduced the gap between tab items from 8px to 3px
- Decreased horizontal padding from 16px to 10px to prevent content overflow
- These changes ensure the "Home, Transactions, Info, Settings" tabs fit properly within the container

These adjustments prevent the tab navigation from exceeding the viewport width, eliminating the unwanted horizontal scrollbar while maintaining the UI's functionality and visual appearance.

### ScreenShot
![image](https://github.com/user-attachments/assets/f2e06088-bcec-4067-996e-814669178db8)

### Related Issue
Fixes #311