### PR TITLE
fix the scroll of modal in deploy and interact

### DIFF
--- a/plugin/src/components/AddDeployedContract/styles.css
+++ b/plugin/src/components/AddDeployedContract/styles.css
@@ -19,6 +19,7 @@
 	padding: 16px;
 	animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
 	box-sizing: border-box;
+	overflow-y: auto;
 }
 
 .add-contract-header {


### PR DESCRIPTION
## Fix modals going out of viewport in deploy/interact sections

- Added `overflow-y: auto` to modal containers in both component style files
- Now modals scroll when content exceeds viewport height
- Bottom action buttons remain accessible

## Screenshot
![image](https://github.com/user-attachments/assets/b74cc7bc-61fb-4f62-be8e-43b2e536efc6)


Closes #308